### PR TITLE
fix: modal delay

### DIFF
--- a/web/static/js/chat_report_feedback.js
+++ b/web/static/js/chat_report_feedback.js
@@ -84,9 +84,11 @@ document.addEventListener('DOMContentLoaded', () => {
     calendarPopup.style.display = 'none';
     fp.close();
 
-    console.log("chatId", chatId);
-    console.log("startDate", startDate);
-    console.log("endDate", endDate);
+
+    feedbackModal.style.display = 'block';
+    progressBar.style.width = '0%';
+    downloadBtn.disabled = true;
+    downloadBtn.classList.remove('active');
 
     const response = await fetch('/chat/report/generate/', {
       method: 'POST',
@@ -103,8 +105,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (!response.ok) {
       alert("해당 날짜에는 상담을 진행하지 않았습니다!");
+      feedbackModal.style.display = 'none';
     } else {
-      feedbackModal.style.display = 'block';
       pollModelStatus();
     }
   });
@@ -130,7 +132,9 @@ document.addEventListener('DOMContentLoaded', () => {
     ratingValue.value = 0;
     feedbackInput.value = '';
     stars.forEach(s => s.src = grayStar);
-    pollModelStatus();
+    progressBar.style.width = '0%';
+    downloadBtn.disabled = true;
+    downloadBtn.classList.remove('active');
   });
 
   function pollModelStatus() {


### PR DESCRIPTION
## ✅ PR 요약
`calendarConfirmBtn` 클릭 시 모달창을 즉시 띄우도록 수정하였습니다.

## 🔍 상세 내용
- `chat_report_feedback.js':

	- 상담 리포트 생성 완료 후에만 피드백 모달창(`feedbackModal`)이 나타나는 딜레이 현상이 있었음
	- **사용자가 날짜 선택 후 `calendarConfirmBtn` 클릭 -> 즉시 피드백 모달창이 열리도록 수정**

## 🔗 관련 이슈
#31 

## 📋 체크리스트
- 테스트 완료


