### PR TITLE
Fix: sidebar

### DIFF
--- a/web/chat/views.py
+++ b/web/chat/views.py
@@ -145,12 +145,12 @@ def guest_profile_register(request):
 def chat_member_talk_detail(request, dog_id, chat_id):
     user_id = request.session.get("user_id")
     if not user_id:
-        return JsonResponse({'error': '로그인 필요'}, status=401)  # 로그인 안 된 경우 JSON 응답으로 처리
+        return JsonResponse({'error': '로그인 필요'}, status=401)  
 
     try:
         user = User.objects.get(id=uuid.UUID(user_id))
     except (User.DoesNotExist, ValueError):
-        return JsonResponse({'error': '사용자를 찾을 수 없습니다.'}, status=404)  # 사용자 없음
+        return JsonResponse({'error': '사용자를 찾을 수 없습니다.'}, status=404) 
 
     dog = DogProfile.objects.filter(id=dog_id).first()
     if not dog or str(dog.user.id) != str(user.id):
@@ -169,7 +169,7 @@ def chat_member_talk_detail(request, dog_id, chat_id):
         elif image_files:
             user_message = Message.objects.create(chat=chat, sender='user', message="[이미지 전송]")
         else:
-            return JsonResponse({'error': '메시지나 이미지를 입력해주세요.'}, status=400)  # 메시지나 이미지 없을 경우
+            return JsonResponse({'error': '메시지나 이미지를 입력해주세요.'}, status=400) 
 
         for img in image_files[:3]:
             try:
@@ -187,8 +187,7 @@ def chat_member_talk_detail(request, dog_id, chat_id):
 
         Message.objects.create(chat=chat, sender='bot', message=answer)
 
-        # 리디렉션 대신 JSON 응답 반환
-        return JsonResponse({'response': answer, 'chat_id': chat.id})  # JSON 응답으로 변경
+        return JsonResponse({'response': answer, 'chat_id': chat.id})  
 
     messages = Message.objects.filter(chat=chat).prefetch_related("images").order_by('created_at')
     chat_list = Chat.objects.filter(dog=dog).order_by('-created_at')
@@ -402,7 +401,6 @@ def chat_send(request):
     if not message and not image_files:
         return redirect(request.META.get('HTTP_REFERER', '/'))
 
-    # ---- 비회원일 때 ----
     if is_guest:
         chat_id = request.session.get("current_chat_id")
         chat = Chat.objects.filter(id=chat_id).first()
@@ -474,9 +472,11 @@ def chat_member_delete(request, dog_id, chat_id):
 
 @require_POST
 @csrf_exempt
-def chat_member_update_title(request, chat_id):
+@require_POST
+@csrf_exempt
+def chat_member_update_title(request, dog_id, chat_id):
     try:
-        chat = get_object_or_404(Chat, id=chat_id)
+        chat = get_object_or_404(Chat, id=chat_id, dog_id=dog_id)
 
         if not is_chat_owner(request, chat):
             return JsonResponse({'status': 'unauthorized'}, status=403)

--- a/web/static/js/chat_member_sidebar.js
+++ b/web/static/js/chat_member_sidebar.js
@@ -41,26 +41,26 @@ function handleTitleClick(event, chatId) {
   goToChat(chatId);
 }
 
-function editChatTitle(chatId) {
+function editChatTitle(chatId, dogId) {
   const input = document.querySelector(`#chat-title-${chatId}`);
   input.removeAttribute("readonly");
   input.focus();
 
-  input.addEventListener("mousedown", (e) => e.stopPropagation(), { once: true });
+  input.addEventListener("mousedown", (e) => e.stopPropagation());
 
   input.addEventListener("keydown", (e) => {
     if (e.key === "Enter") {
       e.preventDefault();
-      saveChatTitle(chatId, input);
+      saveChatTitle(chatId, dogId, input);
     }
-  }, { once: true });
+  });
 
   input.addEventListener("blur", () => {
-    saveChatTitle(chatId, input);
-  }, { once: true });
+    saveChatTitle(chatId, dogId, input);
+  });
 }
 
-function saveChatTitle(chatId, input) {
+function saveChatTitle(chatId, dogId, input) {
   const newTitle = input.value.trim();
   if (!newTitle) {
     alert("제목은 비워둘 수 없습니다.");
@@ -68,7 +68,7 @@ function saveChatTitle(chatId, input) {
     return;
   }
 
-  fetch(`/chat/member/update-title/${chatId}/`, {
+  fetch(`/chat/${dogId}/update-title/${chatId}/`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -86,7 +86,6 @@ function saveChatTitle(chatId, input) {
   });
 }
 
-
 function deleteChat(chatId, dogId) {
   console.log("Deleting chat:", chatId);  
   if (!confirm("이 채팅을 삭제하시겠습니까?")) return;
@@ -94,21 +93,22 @@ function deleteChat(chatId, dogId) {
   const currentPath = window.location.pathname;  
   const expectedPath = `/chat/${dogId}/talk/${chatId}/`;
   const isCurrentChat = currentPath === expectedPath;
+
   fetch(`/chat/${dogId}/delete/${chatId}/`, {
-  method: "POST",
-  headers: {
-    "X-CSRFToken": getCSRFToken(),
-  },
-}).then((res) => {
-  if (res.ok) {
-    document.querySelector(`#chat-${chatId}`)?.remove();
-    if (isCurrentChat) window.location.href = "/chat/main/";
-  } else {
-    res.text().then(msg => {
-      alert("삭제 실패");
-    });
-  }
-});
+    method: "POST",
+    headers: {
+      "X-CSRFToken": getCSRFToken(),
+    },
+  }).then((res) => {
+    if (res.ok) {
+      document.querySelector(`#chat-${chatId}`)?.remove();
+      if (isCurrentChat) window.location.href = "/chat/main/";
+    } else {
+      res.text().then(msg => {
+        alert("삭제 실패");
+      });
+    }
+  });
 }
 
 function goToChat(chatId) {

--- a/web/templates/common/sidebar.html
+++ b/web/templates/common/sidebar.html
@@ -39,8 +39,8 @@
                 <input class="question-text" type="text" id="chat-title-{{ c.id }}" name="title" value="{{ c.chat_title|truncatechars:10 }}" readonly />
               </div>
               <div class="question-icons">
-                <i class="fas fa-pencil-alt" onclick="editChatTitle({{ c.id }})" title="제목 수정"></i>
-                <i class="fas fa-trash" onclick="deleteChat({{ c.id }})" title="삭제하기"></i>
+                <i class="fas fa-pencil-alt" onclick="editChatTitle({{ c.id }}, {{ c.dog.id }})" title="제목 수정"></i>
+                <i class="fas fa-trash" onclick="deleteChat({{ c.id }}, {{ c.dog.id }})" title="삭제하기"></i>
                 <span class="chat-active-indicator"></span>
               </div>
             </div>


### PR DESCRIPTION
## ✅ PR 요약  
사이드바 내 채팅 제목 수정 및 삭제 기능 오류를 수정했습니다.

## 🔍 상세 내용  
- 채팅 제목 수정 버튼 클릭 시 input 전환이 정상 작동하도록 JS 수정  
- Enter 입력 또는 blur 시 제목이 저장되지 않던 문제 해결 (once: true 제거 및 이벤트 바인딩 개선)  
- 수정된 fetch 요청 경로가 view 및 urls.py와 일치하도록 변경 (`/chat/<dog_id>/update-title/<chat_id>/`)  
- 삭제 기능이 현재 채팅일 경우 `/chat/main/`으로 리다이렉트 되도록 보완  
- 템플릿에서 JS 함수 호출 시 `chat_id`와 함께 `dog_id`를 전달하도록 수정  

## 🔗 관련 이슈  
- #52 

## 📋 체크리스트  
- [x] 테스트 완료  
- [x] JS, HTML, View 연동 점검  
- [x] UI 정상 반영 확인  
- [x] 콘솔 에러 여부 확인  
- [x] 비정상 입력 케이스 처리 (`빈 제목 → alert`)