### PR TITLE
fix: 새 채팅 시작 로직 수정

### DIFF
--- a/web/chat/views.py
+++ b/web/chat/views.py
@@ -99,6 +99,7 @@ def chat_member_view(request, dog_id):
         'is_guest': False,
         'user_email': user.email,
         'dog': dog,
+        'dog_id': dog.id,    
         'dog_list': dog_list,
         'can_generate_report': False,
     })
@@ -205,12 +206,14 @@ def chat_member_talk_detail(request, dog_id, chat_id):
         "is_guest": False,
         "now_time": timezone.localtime().strftime("%I:%M %p").lower(),
         "dog": dog,
+        "dog_id": dog.id,
         "dog_list": dog_list,
         'can_generate_report': True,
     })
 
 
 def chat_main(request):
+    dog_id = None
     is_guest = request.session.get("guest", False)
     user_id = request.session.get("user_id")
     guest_user_id = request.session.get("guest_user_id")
@@ -239,9 +242,11 @@ def chat_main(request):
 
             if current_dog_id:
                 current_chat = Chat.objects.filter(dog__id=current_dog_id).first()
+                dog_id = current_dog_id
             else:
                 current_chat = chat_list.first()
                 if current_chat and current_chat.dog:
+                    dog_id = current_chat.dog.id
                     request.session["current_dog_id"] = current_chat.dog.id
 
         except User.DoesNotExist:
@@ -283,6 +288,7 @@ def chat_main(request):
         'guest_dog_name': guest_name,
         'guest_dog_breed': guest_breed,
         'dog_breeds': dog_breeds,
+        'dog_id': dog_id,
         'show_guest_info_form': False,
         'show_login_notice': is_guest 
     })

--- a/web/templates/chat/chat.html
+++ b/web/templates/chat/chat.html
@@ -54,15 +54,8 @@
 
       {% if is_guest and not show_guest_info_form %}
       <div class="chat-message bot-message">
-        <div class="message-text">
-          ✅ 반려견 정보를 등록했어요! <br>이제 궁금한 점을 입력해 상담을 시작해보세요.
-        </div>
       </div>
       <div class="chat-message bot-message" style="background: #fff7e6; color: #a67c00;">
-        <div class="message-text">
-          👉 더 많은 기능은 <strong>로그인</strong> 후 이용하실 수 있어요!
-          <a href="{% url 'user:login' %}" style="margin-left: 8px; color: #007bff;">로그인하러 가기</a>
-        </div>
       </div>
       {% endif %}
 

--- a/web/templates/common/sidebar.html
+++ b/web/templates/common/sidebar.html
@@ -12,9 +12,15 @@
         <img src="{% static 'images/petmind_logo.png' %}" alt="PetMind 로고" class="sidebar-logo">
       </a>
     </div>
-    <a href="{% url 'chat:main' %}" class="chat-new-btn">
-      <img src="{% static 'images/new-chat.png' %}" alt="새 채팅">
-    </a>
+    {% if is_guest %}
+      <a href="{% url 'chat:main' %}" class="chat-new-btn">
+        <img src="{% static 'images/new-chat.png' %}" alt="새 채팅">
+      </a>
+    {% elif dog_id %}
+      <a href="{% url 'chat:chat_member' dog_id %}" class="chat-new-btn">
+        <img src="{% static 'images/new-chat.png' %}" alt="새 채팅">
+      </a>
+    {% endif %}
   </div>
 
   <div class="sidebar-scrollable">

--- a/web/templates/common/sidebar.html
+++ b/web/templates/common/sidebar.html
@@ -12,11 +12,7 @@
         <img src="{% static 'images/petmind_logo.png' %}" alt="PetMind 로고" class="sidebar-logo">
       </a>
     </div>
-    {% if is_guest %}
-      <a href="{% url 'chat:main' %}" class="chat-new-btn">
-        <img src="{% static 'images/new-chat.png' %}" alt="새 채팅">
-      </a>
-    {% elif dog_id %}
+    {% if not is_guest %}
       <a href="{% url 'chat:chat_member' dog_id %}" class="chat-new-btn">
         <img src="{% static 'images/new-chat.png' %}" alt="새 채팅">
       </a>


### PR DESCRIPTION
## ✅ PR 요약
비회원 및 로그인 사용자의 새 채팅 로직 관련 버그 및 UI 이슈를 수정.

## 🔍 상세 내용
- 비회원 사용자의 새 채팅 시작 버튼이 UI에 노출되지 않도록 sidebar템플릿 로직 분기 적용
- 비회원 새 채팅 시도 시 화면 전환 및 버튼 노출 오류 수정
- 로그인 사용자의 새 채팅 시작 시 정상적으로 새로운 채팅방이 생성되고, 기존 채팅방과 분리되도록 로직 수정
- 관련 템플릿 및 context 전달 구조 일관성 개선
- 예외처리 및 조건문 추가로 NoReverseMatch 등 에러 방지

## 🔗 관련 이슈
- Close #54
- Close #48
- Close #46

## 📋 체크리스트
- [x] 테스트 완료
- [x] 문서/주석 최신화
- [x] 빌드 및 실행 정상 확인

