### PR TITLE
Fix: 상담 리포트 버그 수정

### DIFF
--- a/web/chat/report_utils/report_pdf.py
+++ b/web/chat/report_utils/report_pdf.py
@@ -48,3 +48,24 @@ def generate_pdf_from_context(context, pdf_filename="report.pdf"):
 
     return pdf_path
 
+
+import os
+import base64
+import mimetypes
+from django.conf import settings
+
+def get_base64_image(image_path):
+    """
+    MEDIA_ROOT 하위의 상대 경로 image_path를 base64로 인코딩하여 반환.
+    예: image_path='profile_images/1.jpeg'
+    """
+    full_path = os.path.join(settings.MEDIA_ROOT, image_path)
+
+    try:
+        with open(full_path, "rb") as img_file:
+            encoded = base64.b64encode(img_file.read()).decode("utf-8")
+            mime_type, _ = mimetypes.guess_type(full_path)
+            return encoded, mime_type or "image/jpeg"
+    except FileNotFoundError:
+        print(f"[오류] 파일을 찾을 수 없습니다: {full_path}")
+        return None, None

--- a/web/static/js/chat_report_feedback.js
+++ b/web/static/js/chat_report_feedback.js
@@ -84,7 +84,11 @@ document.addEventListener('DOMContentLoaded', () => {
     calendarPopup.style.display = 'none';
     fp.close();
 
-    // 서버에 보고서 생성 요청
+    feedbackModal.style.display = 'block';
+    progressBar.style.width = '0%';
+    downloadBtn.disabled = true;
+    downloadBtn.classList.remove('active');
+
     const response = await fetch('/chat/report/generate/', {
       method: 'POST',
       headers: {
@@ -100,12 +104,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (!response.ok) {
       alert("해당 날짜에는 상담을 진행하지 않았습니다!");
+      feedbackModal.style.display = 'none';  // 실패 시 모달 닫기
     } else {
-      // ✅ 요청 성공 시에만 모달창 열기
-      feedbackModal.style.display = 'block';
-      progressBar.style.width = '0%';
-      downloadBtn.disabled = true;
-      downloadBtn.classList.remove('active');
       pollModelStatus();
     }
   });

--- a/web/templates/chat/report_template.html
+++ b/web/templates/chat/report_template.html
@@ -16,9 +16,9 @@
 
   <div class="profile">
     {% if image %}
-      <img src="data:{{ image_mime_type }};base64,{{ image }}" class="profile-img">
+      <img src="data:{{ image_mime_type }};base64,{{ image }}" alt="{{ dog_name }} 사진" class="profile-img">
     {% else %}
-      <img src="{% static 'images/petmind_logo_dog.png' %}" class="profile-img" alt="기본 반려견 사진">
+      <img src="{% static 'images/petmind_logo_dog.png' %}" alt="기본 반려견 사진" class="profile-img">
     {% endif %}
     <div class="profile-box">
       <span class="name">


### PR DESCRIPTION
## ✅ PR 요약
- 상담 리포트 생성 시 모달 표시 타이밍 개선
- 상담 리포트 PDF에 반려견 프로필 이미지를 `base64`로 삽입하도록 수정했습니다.


## 🔍 상세 내용
- 모달 관련:

	- `calendarConfirmBtn`을 클릭하면 즉시 모달이 뜨도록 타이밍 개선

- 프로필 이미지 관련:

	- `generate_report` 뷰에서 이미지 base64 인코딩 처리 로직 추가
	- `get_base64_image()` 함수 수정
	- 경로 오류 방지를 위해 `"media/", "/media/"` 접두어 제거
	- `MEDIA_ROOT` 기준으로 파일 경로 구성

## 🔗 관련 이슈
- #47 

## 📋 체크리스트
- [x] 테스트 완료
- [x] 문서/주석 최신화
- [x] 빌드 및 실행 정상 확인

## 💬 추가 코멘트
이전에 media 경로가 절대경로로 붙어서 이미지 로드에 실패했었는데,
base64 처리 시 media/ 제거하고 MEDIA_ROOT로 다시 잡아주는 방식으로 해결했습니다.
혹시 모델에 저장된 이미지 경로 포맷이 바뀌면 다시 확인 필요합니다.


