### PR TITLE
fix: chat duplication

### DIFF
--- a/web/chat/views.py
+++ b/web/chat/views.py
@@ -429,6 +429,7 @@ def chat_send(request):
                 MessageImage.objects.create(message=user_message, image=img)
             except Exception:
                 pass
+
         return redirect('chat:chat_talk_detail', chat_id=chat.id)
 
     current_dog_id = request.session.get("current_dog_id")
@@ -442,18 +443,6 @@ def chat_send(request):
         user=user,
         chat_title=message[:20] if message else "상담 시작"
     )
-
-    user_message = Message.objects.create(
-        chat=chat,
-        sender="user",
-        message=message if message else "[이미지 전송]"
-    )
-
-    for img in image_files[:3]:
-        try:
-            MessageImage.objects.create(message=user_message, image=img)
-        except Exception:
-            pass
 
     url = reverse('chat:chat_member_talk_detail', args=[dog.id, chat.id])
     return redirect(f"{url}?just_sent=1&last_msg={quote(message)}")

--- a/web/static/js/chat_talk.js
+++ b/web/static/js/chat_talk.js
@@ -1,5 +1,4 @@
 document.addEventListener('DOMContentLoaded', () => {
-  // 시간 포맷 변환
   document.querySelectorAll(".chat-time").forEach(el => {
     const rawTime = el.getAttribute("data-time");
     if (!rawTime) return;
@@ -9,7 +8,6 @@ document.addEventListener('DOMContentLoaded', () => {
       : '시간 오류';
   });
 
-  // 게스트 체크: 비로그인 사용자 기능 제한
   const isGuest = window.isGuest; 
   if (isGuest) {
     [
@@ -21,12 +19,10 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  // 이미지 미리보기 & 채팅 전송 공통 함수
   let imageInput = document.getElementById('imageInput');
   const imagePreviewContainer = document.getElementById('imagePreviewContainer');
   let currentFileURLs = [];
   
-  // 최초 등록 + 이후 동적 재등록용 함수로 만듦
   function attachImagePreviewListener(input) {
     if (!input || !imagePreviewContainer) {
       console.log('attachImagePreviewListener: input 또는 imagePreviewContainer가 없음');
@@ -91,10 +87,6 @@ document.addEventListener('DOMContentLoaded', () => {
     return result;
   }
 
-
-
-
-  // 채팅 메시지/답변 말풍선 출력
   const chatHistory = document.querySelector('.chat-history');
   const addChatBubble = (message, side = 'user', images = []) => {
     console.log('[addChatBubble] message:', message, 'side:', side, 'images:', images);
@@ -131,15 +123,12 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
 
-
-  // 로딩 애니메이션 말풍선
   const addLoadingBubble = () => addChatBubble(
     `<span class="dot-loader">
       <span class="dot"></span><span class="dot"></span><span class="dot"></span>
     </span>`, 'bot'
   );
 
-  // 채팅 전송 함수
   const sendChat = (form, message, loadingElem) => {
     const formData = new FormData(form);
     formData.set('message', message); 
@@ -191,7 +180,6 @@ document.addEventListener('DOMContentLoaded', () => {
       if (imagePreviewContainer) imagePreviewContainer.innerHTML = '';
       console.log("이미지 미리보기 제거 후:", imagePreviewContainer.innerHTML);
 
-      // 파일 input을 완전히 리셋 
       if (ImageChatingInput && ImageChatingInput.parentNode) {
         ImageChatingInput.value = '';
         const newInput = ImageChatingInput.cloneNode(true);
@@ -199,7 +187,7 @@ document.addEventListener('DOMContentLoaded', () => {
         imageInput = newInput;
         console.log("파일 input 리셋 후 files:", imageInput.files);
         console.log("파일 input 리셋 후 value:", imageInput.value);
-        attachImagePreviewListener(newInput); // 꼭 여기서 미리보기 리스너 재등록!
+        attachImagePreviewListener(newInput); 
         console.log("리스너 재 등록후 files:", imageInput.files);
         console.log("리스너 재 등록후 value:", imageInput.value);
       }
@@ -210,8 +198,6 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   }
 
-
-  // 첫질문 후 chat_talk.html로 로드되며 응답 처리
   const params = new URLSearchParams(window.location.search);
   const justSent = params.get('just_sent');
   const lastMsg = params.get('last_msg');


### PR DESCRIPTION
## ✅ PR 요약  
회원 사용자 채팅 시 동일 메시지의 중복 저장 및 출력 현상 방지를 위한 로직 추가

---

## 🔍 상세 내용  
- 사용자 메시지가 2회 저장되는 문제 해결  
  - `chat_send`에서 회원 사용자는 메시지를 저장하지 않고,  
    `chat_member_talk_detail`에서만 저장하도록 변경
  - `chat_member_talk_detail` 내부에서 `just_sent`, `last_msg` 파라미터 기반 조건 추가 → 한 번만 저장되도록 제어
- 클라이언트 JS(`chat_talk.js`)에서 중복 메시지 렌더링 방지 처리  
  - 동일 텍스트를 가진 사용자 메시지 말풍선이 여러 개 생기지 않도록 `Set()` 활용해 중복 제거
- 중복된 채팅 흐름 방지  
  - 사용자-사용자 메시지가 연속해서 출력되는 UI 흐름 제거

---

## 🔗 관련 이슈  
- Close #56

---

## 📋 체크리스트  
- [x] 메시지 중복 저장 재현 → 해결됨  
- [x] JS 렌더링 중복 제거 정상 동작 확인  
- [x] 최초 메시지 저장 로직 위치 단일화 (POST → chat_member_talk_detail)  

---

## 💬 추가 코멘트  
- 후속적으로 `중복 전송 방지`를 위한 submit 버튼 `disabled 처리`도 고려 필요  