### PR TITLE
fix: chat path modified

### DIFF
--- a/web/static/js/chat_member_sidebar.js
+++ b/web/static/js/chat_member_sidebar.js
@@ -102,7 +102,7 @@ function deleteChat(chatId, dogId) {
   }).then((res) => {
     if (res.ok) {
       document.querySelector(`#chat-${chatId}`)?.remove();
-      if (isCurrentChat) window.location.href = "/chat/main/";
+      if (isCurrentChat) window.location.href = `/chat/${dogId}/`;
     } else {
       res.text().then(msg => {
         alert("삭제 실패");


### PR DESCRIPTION
## ✅ PR 요약
회원 채팅 내역 삭제 후 비회원 페이지로 이동하던 문제를 수정하여, `dogId` 기반 회원 전용 페이지로 이동하도록 변경했습니다.

## 🔍 상세 내용
- 삭제 후 리디렉션 경로를 `/chat/main/`에서 `/chat/${dogId}/`로 수정
- 해당 변경은 회원 채팅 삭제 시 현재 페이지가 삭제된 채팅일 경우에만 적용됨

## 🔗 관련 이슈
- #52 
- #60 

## 📋 체크리스트
- [] 삭제 시 올바른 경로로 리디렉션 되는지 확인
- [] 비회원 채팅은 영향을 받지 않는지 확인
- [] `dogId`가 유효한 경우에만 작동하는지 테스트 완료

## 💬 추가 코멘트
테스트는 로컬에서 진행되었으며, dev 브랜치 기준 정상 작동 확인했습니다


