### PR TITLE
fix: 사용자 및 모델 메시지에 실시간 타임스탬프 표시 기능 개선

### DIFF
--- a/web/static/css/chat_talk.css
+++ b/web/static/css/chat_talk.css
@@ -20,7 +20,7 @@
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 25px;
   margin: 24px 0 24px 0;
   width: 100%;
   max-width: 60%;
@@ -45,7 +45,6 @@
 .chat-message {
   width: fit-content;
   max-width: 100%;
-  padding: 16px 20px;
   border-radius: 12px;
   font-size: 15px;
   line-height: 1.8;
@@ -60,6 +59,7 @@
 }
 .user-message {
   background: #FFFFDB;
+  padding: 16px 20px;
   color: #2B2F31;
   border-top-right-radius: 0;
 }
@@ -84,7 +84,6 @@
   background: #FFFFDB;
   border-radius: 16px;
   box-shadow: 0 2px 12px rgba(180,180,100,0.04);
-  margin-bottom: 24px;
   padding: 20px 24px 16px 24px;
   transition: box-shadow .2s;
 }
@@ -422,6 +421,15 @@
   margin-top: 4px;
 }
 
+.left-time {
+  align-self: flex-start;
+  margin-top: 43.5px;
+}
+
+.right-time {
+  align-self: flex-end;
+}
+
 
 @media (max-width: 768px) {
   .chat-main {
@@ -433,7 +441,7 @@
   .chat-message-wrapper {
     max-width: 100%;
   }
-
+  
   .chat-message {
     font-size: 15px;
     padding: 14px 16px;


### PR DESCRIPTION
## ✅ PR 요약
메시지 전송 및 모델 응답 시, 사용자/모델 말풍선에 응답 시간이 즉시 표시되도록 전체 로직과 CSS를 개선.

## 🔍 상세 내용
- 채팅방 입장 후 모든 채팅 메시지(사용자/모델) 전송 시, 말풍선 옆에 응답 시간(`오전/오후 시:분` 포맷)이 즉시 노출되도록 JS에서 `formatKoreanTime` 함수 생성 및 `addChatBubble` 로직 보강 
- 서버에서 내려준 `created_at` 값을 기준으로, 없을 경우 JS에서 현재 시각을 생성해 사용
- 시간 포맷을 기존 템플릿 스타일과 동일하게 “오전/오후 시:분”으로 통일
- `chat_talk.css`의 `left-time`, `right-time`, `answer-section`, `chat-message` 를 수정하여 응답 시간이 말풍선 우측 하단에 자연스럽게 붙고, 색상·폰트·여백 등 시각적으로 깔끔하게 보이도록 스타일 최적화

## 🔗 관련 이슈
- Fixes #62 

## 📋 체크리스트
- [x] 테스트 완료
- [x] 문서/주석 최신화
- [x] 빌드 및 실행 정상 확인
