### PR TITLE
fix: chat report image

### DIFF
--- a/ai-engine/model_code/qwen3_chat_response.ipynb
+++ b/ai-engine/model_code/qwen3_chat_response.ipynb
@@ -731,12 +731,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "336150a8-f193-484b-83ff-9d721dfbb5d3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "# ========== 프롬프트 매핑 ==========\n",
     "PROMPT_MAP = {\n",
     "    \"행동 교정\": \"\"\"당신은 반려견 행동 문제를 상담해주는 전문가입니다.\n",

--- a/web/chat/views.py
+++ b/web/chat/views.py
@@ -32,6 +32,7 @@ from django.utils.timezone import make_aware
 from urllib.parse import quote
 from django.urls import reverse
 import mimetypes
+from urllib.parse import unquote
 
 
 def chat_entry(request):
@@ -791,9 +792,13 @@ def generate_report(request):
     mime_type = None
     if dog.get("image"):
         try:
-            base64_img, mime_type = get_base64_image(dog["image"])
+            image_path = dog["image"]
+            # print("🐾 원본 image 경로:", dog["image"])
+            cleaned_image_path = unquote(image_path.replace("/media/", ""))
+            # print("🐾 media/ 제거된 경로:", cleaned_image_path)
+            base64_img, mime_type = get_base64_image(cleaned_image_path)
         except Exception as e:
-            print(f"[경고] 이미지 Base64 변환 실패: {e}")
+            # print(f"[경고] 이미지 Base64 변환 실패: {e}")
             base64_img = None
             mime_type = None
 


### PR DESCRIPTION
## ✅ PR 요약
한글로 된 반려견 이미지 파일명이 상담 리포트에 출력되지 않던 문제를 해결했습니다.

## 🔍 상세 내용
- `views.py`:
	- `generate_report()`에서 `dog["image"]` 경로에서 `/media/` 제거 후 `unquote()`를 적용하여 경로 디코딩 처리

- `report_pdf.py`:
	- `get_base64_image()`에서 디버깅 로그와 함께 `unquote()`를 통해 인코딩된 파일명을 복원하고 `os.path.exists()`로 파일 존재 여부를 명확하게 확인

- `한글 파일명(%EB...)`을 가진 이미지도 정상적으로 `base64`로 인코딩되어 리포트에 포함되도록 개선

## 🔗 관련 이슈
- #68 

## 📋 체크리스트
- [x] 테스트 완료 (파일명에 한글, 띄어쓰기, 영문, 특수문자 등이 포함된 프로필 이미지로 리포트 생성 확인)
- [x] 디버깅 로그로 파일 경로 흐름 확인
- [x] 빌드 및 실행 정상 확인



