### PR TITLE
Fix: image upload & health message

### DIFF
--- a/web/static/css/chat.css
+++ b/web/static/css/chat.css
@@ -403,7 +403,7 @@ body {
 }
 
 /* 화면 하단 안내 문구 고정 */
-.fixed-helper-text {
+.helper-text {
   position: fixed;
   left: 0;
   bottom: 0;

--- a/web/static/css/chat.css
+++ b/web/static/css/chat.css
@@ -401,3 +401,16 @@ body {
     display: none;
   }
 }
+
+/* 화면 하단 안내 문구 고정 */
+.fixed-helper-text {
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  width: 100vw;
+  color: #b0b0b0;
+  font-size: 13px;
+  text-align: center;
+  padding: 12px 0 10px 0;
+  z-index: 1000;
+}

--- a/web/templates/chat/chat.html
+++ b/web/templates/chat/chat.html
@@ -70,7 +70,7 @@
         <textarea name="message" placeholder="질문을 입력하세요." required></textarea>
         <div id="imagePreviewContainer" style="display: flex; gap: 8px; margin-top: 8px;"></div>
         <div class="chat-input-bottom">
-          <label class="image-upload-btn">
+          <label class="image-upload-btn" style="visibility: hidden;">
             <input type="file" name="images" id="imageInput" accept="image/*" multiple hidden>
             <img src="{% static 'images/image_upload_btn.png' %}" alt="이미지 업로드 아이콘">
             <span>이미지 업로드</span>
@@ -79,13 +79,16 @@
             <img src="{% static 'images/chatbot_sendbtn.png' %}" alt="보내기">
           </button>
         </div>
-
+    
         <input type="hidden" id="guestDogName" value="{{ guest_dog_name|default_if_none:'' }}">
         <input type="hidden" id="guestDogBreed" value="{{ guest_dog_breed|default_if_none:'' }}">
-      </form>
+      </form>        
+
     </div>
   </main>
 </div>
+
+<div class="fixed-helper-text">PetMind는 반려견의 이해를 돕는 AI 상담 도우미입니다. 반려견의 건강 문의 사항은 전문가와 상의해보세요.</div>
 
 <script src="{% static 'js/chat_member_sidebar.js' %}"></script>
 <script src="{% static 'js/image_upload.js' %}"></script>

--- a/web/templates/chat/chat.html
+++ b/web/templates/chat/chat.html
@@ -88,7 +88,7 @@
   </main>
 </div>
 
-<div class="fixed-helper-text">PetMind는 반려견의 이해를 돕는 AI 상담 도우미입니다. 반려견의 건강 문의 사항은 전문가와 상의해보세요.</div>
+<div class="helper-text">PetMind는 반려견의 이해를 돕는 AI 상담 도우미입니다. 반려견의 건강 문의 사항은 전문가와 상의해보세요.</div>
 
 <script src="{% static 'js/chat_member_sidebar.js' %}"></script>
 <script src="{% static 'js/image_upload.js' %}"></script>

--- a/web/templates/chat/chat_talk.html
+++ b/web/templates/chat/chat_talk.html
@@ -102,7 +102,7 @@
           </button>
         </div>
       </form>
-      <div class="fixed-helper-text">PetMind는 반려견의 이해를 돕는 AI 상담 도우미입니다. 반려견의 건강 문의 사항은 전문가와 상의해보세요.</div>
+      <div class="helper-text">PetMind는 반려견의 이해를 돕는 AI 상담 도우미입니다. 반려견의 건강 문의 사항은 전문가와 상의해보세요.</div>
     </main>
   </div>
   <span id="isGuestFlag" style="display: none;">{{ is_guest|yesno:"true,false" }}</span>

--- a/web/templates/chat/chat_talk.html
+++ b/web/templates/chat/chat_talk.html
@@ -102,6 +102,7 @@
           </button>
         </div>
       </form>
+      <div class="fixed-helper-text">PetMind는 반려견의 이해를 돕는 AI 상담 도우미입니다. 반려견의 건강 문의 사항은 전문가와 상의해보세요.</div>
     </main>
   </div>
   <span id="isGuestFlag" style="display: none;">{{ is_guest|yesno:"true,false" }}</span>


### PR DESCRIPTION
## ✅ PR 요약  
이미지 업로드 버튼을 숨기고, 건강 안내 문구가 채팅 하단에 고정되어 출력되도록 개선했습니다.

## 🔍 상세 내용
- chat.html에서 이미지 업로드 버튼을 `style="visibility: hidden;"` 속성으로 숨김 처리
- chat_talk.html, chat.html에 건강 안내 문구 출력 로직 추가
- CSS에 `.fixed-helper-text` 클래스를 추가하여 채팅 화면 하단에 안내 문구가 항상 노출되도록 적용
- 안내 문구:  
  **"PetMind는 반려견의 이해를 돕는 AI 상담 도우미입니다. 반려견의 건강 문의 사항은 전문가와 상의해보세요."**

## 📋 체크리스트
- [x] 테스트 완료
- [x] 문서/주석 최신화
- [ ] 빌드 및 실행 정상 확인