### PR TITLE
fix: sidebar chat title

### DIFF
--- a/web/static/css/sidebar.css
+++ b/web/static/css/sidebar.css
@@ -73,7 +73,28 @@
   display: none;
 }
 
-/* ===== 질문 아이템 ===== */
+.chat-title-input {
+  font-size: 14px;
+  color: #333;
+  background-color: transparent;
+  border: none;
+  outline: none;
+  width: 100%;
+  padding: 4px 0;
+  font-family: 'Spoqa Han Sans Neo', sans-serif;
+  cursor: pointer;
+}
+
+.chat-title-input:not([readonly]) {
+  border-bottom: 1px solid #ccc;
+  background-color: #fffdf2;
+  cursor: text;
+}
+
+.chat-title-input::placeholder {
+  color: #bbb;
+}
+
 .question-item {
   display: flex;
   align-items: center;
@@ -115,7 +136,6 @@
   pointer-events: none;
 }
 
-/* 호버 시 아이콘 및 원 표시 */
 .question-item:hover .question-icons i,
 .question-item:hover .chat-active-indicator {
   display: inline-block;

--- a/web/static/js/chat_member_sidebar.js
+++ b/web/static/js/chat_member_sidebar.js
@@ -8,10 +8,7 @@ document.addEventListener("DOMContentLoaded", () => {
       e.stopPropagation();
       const isOpen = sidebar.classList.toggle("active");
       appWrapper?.classList.toggle("sidebar-open", isOpen);
-
-      if (isOpen) {
-        appWrapper?.classList.remove("right-open");
-      }
+      if (isOpen) appWrapper?.classList.remove("right-open");
     });
   });
 
@@ -30,41 +27,61 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   sidebar?.addEventListener("click", (e) => e.stopPropagation());
-});
 
-function handleTitleClick(event, chatId) {
-  const input = document.querySelector(`#chat-title-${chatId}`);
-  if (!input.hasAttribute("readonly")) {
-    event.stopPropagation(); 
-    return;
-  }
-  goToChat(chatId);
-}
+  document.querySelectorAll(".chat-title-input").forEach((input) => {
+    const chatId = input.dataset.chatId;
+    const dogId = input.dataset.dogId;
+
+    input.addEventListener("click", (e) => {
+      if (input.hasAttribute("readonly")) {
+        goToChat(chatId, dogId);
+      } else {
+        e.stopPropagation(); 
+      }
+    });
+
+    input.addEventListener("mousedown", (e) => {
+      if (!input.hasAttribute("readonly")) {
+        e.stopPropagation();
+      }
+    });
+
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        saveChatTitle(chatId, dogId, input, true); 
+      }
+    });
+
+    input.addEventListener("blur", () => {
+      saveChatTitle(chatId, dogId, input, false);
+    });
+  });
+});
 
 function editChatTitle(chatId, dogId) {
   const input = document.querySelector(`#chat-title-${chatId}`);
   input.removeAttribute("readonly");
   input.focus();
-
-  input.addEventListener("mousedown", (e) => e.stopPropagation());
-
-  input.addEventListener("keydown", (e) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      saveChatTitle(chatId, dogId, input);
-    }
-  });
-
-  input.addEventListener("blur", () => {
-    saveChatTitle(chatId, dogId, input);
-  });
+  input.dataset.originalTitle = input.value; 
 }
 
-function saveChatTitle(chatId, dogId, input) {
+function saveChatTitle(chatId, dogId, input, shouldRedirect = false) {
+  if (input.hasAttribute("readonly")) return;
+
   const newTitle = input.value.trim();
+  const originalTitle = (input.dataset.originalTitle || "").trim();
+
   if (!newTitle) {
     alert("제목은 비워둘 수 없습니다.");
-    input.focus();
+    input.value = originalTitle || "제목 없음";
+    input.setAttribute("readonly", true);
+    return;
+  }
+
+  if (newTitle === originalTitle) {
+    input.setAttribute("readonly", true);
+    if (shouldRedirect) goToChat(chatId, dogId);
     return;
   }
 
@@ -75,22 +92,25 @@ function saveChatTitle(chatId, dogId, input) {
       "X-CSRFToken": getCSRFToken(),
     },
     body: JSON.stringify({ title: newTitle }),
-  }).then((res) => {
-    if (res.ok) {
-      input.setAttribute("readonly", true);
-    } else {
-      alert("제목 수정 실패");
-    }
-  }).catch((e) => {
-    alert("서버 오류: " + e.message);
-  });
+  })
+    .then((res) => {
+      if (res.ok) {
+        input.setAttribute("readonly", true);
+        input.dataset.originalTitle = newTitle;
+        if (shouldRedirect) goToChat(chatId, dogId);
+      } else {
+        alert("제목 수정 실패");
+      }
+    })
+    .catch((e) => {
+      alert("서버 오류: " + e.message);
+    });
 }
 
 function deleteChat(chatId, dogId) {
-  console.log("Deleting chat:", chatId);  
   if (!confirm("이 채팅을 삭제하시겠습니까?")) return;
 
-  const currentPath = window.location.pathname;  
+  const currentPath = window.location.pathname;
   const expectedPath = `/chat/${dogId}/talk/${chatId}/`;
   const isCurrentChat = currentPath === expectedPath;
 
@@ -104,23 +124,20 @@ function deleteChat(chatId, dogId) {
       document.querySelector(`#chat-${chatId}`)?.remove();
       if (isCurrentChat) window.location.href = `/chat/${dogId}/`;
     } else {
-      res.text().then(msg => {
-        alert("삭제 실패");
-      });
+      alert("삭제 실패");
     }
   });
 }
 
-function goToChat(chatId) {
+function goToChat(chatId, dogId) {
   const form = document.createElement("form");
-  form.method = "POST";
-  form.action = `/chat/member/chat/${chatId}/`;
+  form.method = "GET";
+  form.action = `/chat/${dogId}/talk/${chatId}/`;
 
-  const csrfToken = getCSRFToken();
   const csrfInput = document.createElement("input");
   csrfInput.type = "hidden";
   csrfInput.name = "csrfmiddlewaretoken";
-  csrfInput.value = csrfToken;
+  csrfInput.value = getCSRFToken();
   form.appendChild(csrfInput);
 
   document.body.appendChild(form);
@@ -129,6 +146,8 @@ function goToChat(chatId) {
 
 function getCSRFToken() {
   const name = "csrftoken";
-  const cookie = document.cookie.split(";").find((c) => c.trim().startsWith(name + "="));
+  const cookie = document.cookie
+    .split(";")
+    .find((c) => c.trim().startsWith(name + "="));
   return cookie ? cookie.trim().split("=")[1] : "";
 }

--- a/web/templates/common/sidebar.html
+++ b/web/templates/common/sidebar.html
@@ -38,7 +38,17 @@
             <div class="question-item{% if current_chat and current_chat.id == c.id %} active{% endif %}" id="chat-{{ c.id }}">
               <div class="question-info" onclick="location.href='{% url 'chat:chat_member_talk_detail' c.dog.id c.id %}'">
                 <img src="{% static 'images/chat-history.png' %}" alt="채팅 아이콘">
-                <input class="question-text" type="text" id="chat-title-{{ c.id }}" name="title" value="{{ c.chat_title|truncatechars:10 }}" readonly />
+                {% comment %} <input class="question-text" type="text" id="chat-title-{{ c.id }}" name="title" value="{{ c.chat_title|truncatechars:10 }}" readonly /> {% endcomment %}
+                <input
+                  class="chat-title-input"
+                  id="chat-title-{{ c.id }}"
+                  data-chat-id="{{ c.id }}"
+                  data-dog-id="{{ c.dog.id }}"
+                  type="text"
+                  name="title"
+                  value="{{ c.chat_title }}"
+                  readonly
+                />
               </div>
               <div class="question-icons">
                 <i class="fas fa-pencil-alt" onclick="editChatTitle({{ c.id }}, {{ c.dog.id }})" title="제목 수정"></i>
@@ -59,7 +69,6 @@
     {% endif %}
   </div>
 
-  <!-- 환경설정 버튼 -->
   <div class="sidebar-settings-btn-wrapper">
     <button id="settingsBtn" class="settings-btn">
       <img src="{% static 'images/setting.png' %}" alt="환경설정" />


### PR DESCRIPTION
## ✅ PR 요약
채팅 제목 수정 시 입력값이 비어 있을 경우 예외 처리를 개선하고, 무한 alert 현상을 방지하였습니다.

## 🔍 상세 내용
- 채팅 제목을 비운 채 Enter 입력 시 무한 alert 반복되는 문제 해결
- 입력값이 비어 있을 경우 readonly 속성을 즉시 복원하여 중복 이벤트 방지
- 저장 실패 시 원래 제목으로 되돌리고 focus 해제 처리
- 입력창 클릭 시에는 이동하지 않고, Enter 시에만 이동하도록 조건 분기
- 저장 성공 시에도 이동이 필요한 경우에만 goToChat 호출

## 🔗 관련 이슈
- #75

## 📋 체크리스트
- [x] 비어 있는 제목 입력 시 정상적으로 alert 출력 및 종료
- [x] 제목 수정 후 Enter 시 정상 저장 및 채팅 이동
- [x] blur 시 저장은 되지만 이동은 발생하지 않음
- [x] UI 테스트 완료 (PC / 모바일)