### PR TITLE
fix: pwd validation & alert messages

### DIFF
--- a/web/templates/common/update_modal.html
+++ b/web/templates/common/update_modal.html
@@ -17,11 +17,11 @@
 
       <label for="current_password" class="modal-label">기존 비밀번호<span class="label-star">*</span></label>
       <input type="password" id="current_password" name="current_password" placeholder="기존 비밀번호 입력" required />
-      <small class="password-hint">※ 영문 대/소문자, 숫자, 특수문자를 2종류 혼용하여 8~16자 입력</small>
+      <small class="password-hint">※ 영문, 숫자, 특수문자를 혼용하여 8~16자 입력</small>
 
       <label for="new_password" class="modal-label">변경 비밀번호<span class="label-star">*</span></label>
       <input type="password" id="new_password" name="new_password" placeholder="변경할 비밀번호 입력" required />
-      <small class="password-hint">※ 영문 대/소문자, 숫자, 특수문자를 2종류 혼용하여 8~16자 입력</small>
+      <small class="password-hint">※ 영문, 숫자, 특수문자를 혼용하여 8~16자 입력</small>
 
       <div id="updateMessage" style="margin-top: 10px; font-size: 14px;"></div>
 
@@ -54,14 +54,22 @@
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     const updateForm = document.getElementById('updateForm');
+
     if (updateForm) {
       updateForm.addEventListener('submit', async function (e) {
         e.preventDefault();
 
         const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
-        const current = document.getElementById('current_password').value;
-        const newpw = document.getElementById('new_password').value;
+        const current = document.getElementById('current_password').value.trim();
+        const newpw = document.getElementById('new_password').value.trim();
         const msgBox = document.getElementById('updateMessage');
+
+        const pwRegex = /^(?=.*[A-Za-z])(?=.*\d|[^A-Za-z\d])(?=.{8,16}).*$/;
+        if (!pwRegex.test(newpw)) {
+          msgBox.style.color = 'red';
+          msgBox.innerText = '비밀번호는 영문, 숫자, 특수문자를 2종류 혼용하여 8~16자로 입력해주세요.';
+          return;
+        }
 
         const response = await fetch("{% url 'user:update_info' %}", {
           method: 'POST',

--- a/web/templates/user/join_01.html
+++ b/web/templates/user/join_01.html
@@ -69,6 +69,9 @@
               <option value="">직접 입력</option>
               <option value="gmail.com">gmail.com</option>
               <option value="naver.com">naver.com</option>
+              <option value="daum.net">daum.net</option>
+              <option value="hanmail.net">hanmail.net</option>
+              <option value="nate.com">nate.com</option>
             </select>
             <button type="button" class="btn-auth-request">인증 번호 요청</button>
           </div>
@@ -87,7 +90,7 @@
         <label for="password" id="password-label">비밀번호<span style="color:#FFC508;">*</span></label>
         <div class="password-group-wrapper">
           <input type="password" name="password" id="password" placeholder="비밀번호를 입력하세요">
-          <p class="helper-text" id="password-helper">※ 영문 대/소문자, 숫자, 특수문자를 2종류 혼합하여 8~16자 입력</p>
+          <p class="helper-text" id="password-helper">※ 영문, 숫자, 특수문자를 2종류 혼용하여 8~16자 입력</p>
           <p class="helper-text error-message" id="password-error"></p>
         </div>
       </div>
@@ -184,9 +187,19 @@
       const validEmail = /^[a-z0-9]{5,20}$/.test(emailVal);
       const validPassword = /^(?=.*[A-Za-z])(?=.*\d|[^A-Za-z\d])(?=.{8,16}).*$/.test(passwordVal);
 
-      if (!validEmail || !validPassword || !isAgreed) {
+      if (!validEmail) {
         e.preventDefault();
-        alert("입력값을 다시 확인해주세요.");
+        alert("이메일 형식을 확인해주세요.");
+        return;
+      }
+      if (!validPassword) {
+        e.preventDefault();
+        alert("비밀번호 조건을 확인해주세요.");
+        return;
+      }
+      if (!isAgreed) {
+        e.preventDefault();
+        alert("필수 약관에 동의해주세요.");
         return;
       }
 

--- a/web/templates/user/join_p_terms_privacy.html
+++ b/web/templates/user/join_p_terms_privacy.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <title>개인정보처리방침</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="{% static 'images/petmind_logo_dog.png' %}" type="image/png" />
 
     <!-- ✅ 폰트 CDN -->
     <link href='//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css' rel='stylesheet' type='text/css'>

--- a/web/templates/user/join_p_terms_service.html
+++ b/web/templates/user/join_p_terms_service.html
@@ -5,8 +5,6 @@
     <meta charset="UTF-8">
     <title>서비스 이용약관</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="{% static 'images/petmind_logo_dog.png' %}" type="image/png" />
-
 
     <!-- ✅ 폰트 CDN -->
     <link href='//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
## ✅ PR 요약
회원가입 폼에 비밀번호 유효성 검사를 추가하고, 이메일 샘플 추가와 회원가입 시 각 조건별(약관 동의/이메일 형식/비밀번호 조건)로 명확한 안내 문구를 출력하도록 수정하였습니다.

## 🔍 상세 내용
- **`join_01.html`**:


	- **비밀번호 유효성 검사 정규식 적용**: `^(?=.*[A-Za-z])(?=.*\d|[^A-Za-z\d])(?=.{8,16}).*$`
	
	- **이메일 샘플 추가**: 가장 많이 사용하는 상위 5개 이메일(naver.com/gmail.com/daum.net/hanmail.net/nate.com)로 수정
	
	- **기존 안내 문구** 
	유효성 검사를 통합해 "이메일 형식을 확인해주세요"라는 문구만 출력

	- **변경 안내 문구**:
	이메일 형식 오류 → `"이메일 형식을 확인해주세요"`
	비밀번호 형식 오류 → `"비밀번호 조건을 확인해주세요"`
	약관 미동의 시 → `"필수 약관에 동의해주세요"`


## 🔗 관련 이슈
- #77 
- #78 

## 📋 체크리스트
- [x] 테스트 완료
- [x] 문서/주석 최신화


