### PR TITLE
Fix: chat message stream

### DIFF
--- a/web/chat/templatetags/custom_markdown.py
+++ b/web/chat/templatetags/custom_markdown.py
@@ -8,10 +8,8 @@ def custom_markdown_parse(value):
     if not value:
         return ''
 
-    # 1) 숫자 리스트 바로 앞의 빈 줄 제거
     value = re.sub(r'^\s*\n(?=\d+\.)', '', value, flags=re.MULTILINE)
 
-    # 2) 불릿 리스트 항목 사이의 빈 줄 제거 (연속된 '-' 항목이 하나의 블록으로 묶이도록)
     value = re.sub(
         r'(^-\s.*?)(?:\n\s*\n)+(?=-\s)',
         r'\1\n',
@@ -19,7 +17,6 @@ def custom_markdown_parse(value):
         flags=re.MULTILINE
     )
 
-    # 3) 인용부호 내부 구두점 보호
     def protect_quotes(match):
         text = match.group(0)
         return (text.replace('.', '[[DOT]]')
@@ -27,15 +24,12 @@ def custom_markdown_parse(value):
                     .replace('?', '[[QST]]'))
     value = re.sub(r'"[^"]*"|\'[^\']*\'|`[^`]*`', protect_quotes, value)
 
-    # 4) 커스텀 헤딩 변환
     value = re.sub(r'\*\*?분석\*\*?(?::)?\s?', '### ✅ 문제 행동 분석\n', value)
     value = re.sub(r'\*\*?해결책 제시\*\*?(?::)?\s?', '\n### 🐾 솔루션\n', value)
     value = re.sub(r'\*\*?추가 질문\*\*?(?::)?\s?', '\n### 추가 질문\n', value)
 
-    # 5) 볼드 처리
     value = re.sub(r'\*\*(.+?)\*\*', r'<b>\1</b>', value)
 
-    # 6) 숫자 리스트 블록 → <ol>...</ol>
     value = re.sub(
         r'((?:^\d+\.\s.+\n?)+)',
         lambda m: (
@@ -50,7 +44,6 @@ def custom_markdown_parse(value):
         flags=re.MULTILINE
     )
 
-    # 7) 불릿 리스트 블록 → <ul>...</ul>
     value = re.sub(
         r'((?:^-\s.+\n?)+)',
         lambda m: (
@@ -65,23 +58,18 @@ def custom_markdown_parse(value):
         flags=re.MULTILINE
     )
 
-    # 8) 남은 <br> 중복 제거
     value = re.sub(r'(<br>\s*){2,}', '<br>', value)
 
-    # 9) ### → <h3>
     value = re.sub(r'^### (.+)$', r'<h3>\1</h3>', value, flags=re.MULTILINE)
 
-    # 10) 섹션별로 감싸기
     def section_divs(match):
         title, content = match.group(1), match.group(2)
         return f'<div class="answer-section"><h3>{title}</h3>{content.strip()}</div>'
     value = re.sub(r'<h3>(.*?)<\/h3>(.*?)(?=<h3>|$)', section_divs, value, flags=re.DOTALL)
 
-    # 11) 섹션이 하나도 없으면 전체 감싸기
     if '<div class="answer-section">' not in value:
         value = f'<div class="answer-section">{value.strip()}</div>'
 
-    # 12) 보호된 구두점 복원
     return (value
             .replace('[[DOT]]', '.')
             .replace('[[EXCL]]', '!')

--- a/web/static/css/chat_talk.css
+++ b/web/static/css/chat_talk.css
@@ -98,7 +98,7 @@
   padding: 20px 24px 16px 24px;
   transition: box-shadow .2s;
   word-wrap: break-word;
-  white-space: pre-wrap;
+  /* white-space: pre-wrap; */
   overflow-wrap: break-word;
 }
 .answer-section h3 {

--- a/web/static/js/chat_talk.js
+++ b/web/static/js/chat_talk.js
@@ -86,7 +86,7 @@ function customMarkdownParse(text) {
       .map(line => line.replace(/^\d+\.\s/, '').trim())
       .map(content => `<li>${content}</li>`)
       .join('');
-    return `<ol style="margin:0.5em 0 0 1.2em; padding:0;">${items}</ol>`;
+    return `<ol>${items}</ol>`;
   });
 
   text = text.replace(/((?:^-\s.+\n?)+)/gm, (match) => {
@@ -95,7 +95,7 @@ function customMarkdownParse(text) {
       .map(line => line.replace(/^- /, '').trim())
       .map(content => `<li>${content}</li>`)
       .join('');
-    return `<ul style="margin:0.5em 0 0 1.2em; padding:0;">${items}</ul>`;
+    return `<ul>${items}</ul>`;
   });
 
   text = text.replace(/^### (.+)$/gm, '<h3>$1</h3>');
@@ -105,12 +105,8 @@ function customMarkdownParse(text) {
   let m;
   while ((m = sectionRegex.exec(text)) !== null) {
     result += `
-      <div class="answer-section" style="
-        line-height:1.5; font-size:15px; margin-bottom:1.2em;
-        background:#fffbe6; border-left:4px solid #ffd54f;
-        border-radius:8px; padding:12px 16px;
-      ">
-        <h3 style="font-size:16px; font-weight:bold; color:#333; margin:0 0 0.5em;">
+      <div class="answer-section">
+        <h3>
           ${m[1]}
         </h3>
         ${m[2].trim()}
@@ -127,7 +123,7 @@ function customMarkdownParse(text) {
     .replace(/\[\[EXCL\]\]/g, '!')
     .replace(/\[\[QST\]\]/g, '?');
 
-  return result;
+  return result.trim();
 }
 
   const chatHistory = document.querySelector('.chat-history');
@@ -195,7 +191,8 @@ function customMarkdownParse(text) {
       method: 'POST',
       body: formData,
       headers: {
-        'X-CSRFToken': form.querySelector('[name="csrfmiddlewaretoken"]').value
+        'X-CSRFToken': form.querySelector('[name="csrfmiddlewaretoken"]').value,
+        'X-Requested-With': 'XMLHttpRequest' 
       },
       credentials: 'same-origin'
     });
@@ -236,13 +233,17 @@ function customMarkdownParse(text) {
     }
 
     let finalText = fullText.trim();
-    try {
-      const parsedJson = JSON.parse(finalText);
-      if (parsedJson.response) {
-        finalText = parsedJson.response;
-      }
-    } catch (e) {
-    }
+
+    // try {
+    //   const parsedJson = JSON.parse(finalText);
+    //   if (typeof parsedJson.response === "string") {
+    //     finalText = parsedJson.response;
+    //   } else {
+    //     finalText = JSON.stringify(parsedJson.response);
+    //   }
+    // } catch (e) {
+    //   console.warn("JSON 파싱 실패", e);
+    // }
 
     contentDiv.innerHTML = customMarkdownParse(finalText);
 

--- a/web/templates/chat/chat_talk.html
+++ b/web/templates/chat/chat_talk.html
@@ -65,7 +65,7 @@
            data-url="{% url 'chat:recommend_content' chat_id=current_chat.id %}"
            style="cursor:pointer;">
         <img src="{% static 'images/recommendation_btn.png' %}" alt="추천 아이콘" class="recommend-icon">
-        <span class="recommend-text">이런 정보는 어때요? 추천 컨텐츠를 확인해보세요.</span>
+        <span class="recommend-text">이런 정보는 어때요? 추천 콘텐츠를 확인해보세요.</span>
       </div>
 
       <form method="POST"


### PR DESCRIPTION
## ✅ PR 요약
메시지 전송 시에도 스트리밍 응답이 작동하도록 구조를 수정하고, 출력 오류를 해결했습니다.

## 🔍 상세 내용
- `chat_send`에서 redirect 방식 제거 → JSON 응답으로 구조 통일
- 회원/비회원 공통으로 JS에서 첫 메시지도 `fetch()`로 전송하도록 수정
- `sendChat()` 함수에서 최초 메시지도 스트리밍 처리되도록 개선
- 스트리밍 중 한글 깨짐, `"request:"` 등 불필요한 문자열 제거
- 스트리밍 도중 마크다운 구조가 깨지거나 말풍선이 비정상적으로 커지는 현상 해결

## 🔗 관련 이슈
- #93

## 📋 체크리스트
- [x] 테스트 완료