### PR TITLE
fix: link

### DIFF
--- a/web/templates/common/chat_header.html
+++ b/web/templates/common/chat_header.html
@@ -16,7 +16,11 @@
       <div style="width: 40px;"></div>
     {% endif %}
 
-    <a href="{% url 'chat:main' %}" class="chat-logo">PetMind</a>
+    {% if is_guest %}
+      <a href="{% url 'chat:main' %}" class="chat-logo">PetMind</a>
+    {% else %}
+      <a href="{% url 'chat:chat_member' dog.id %}" class="chat-logo">PetMind</a>
+    {% endif %}
 
     
     {% if not hide_report_button %}


### PR DESCRIPTION
## ✅ PR 요약  
PetMind 로고 클릭 시 회원/비회원에 따라 이동 경로를 분기 처리했습니다.

## 🔍 상세 내용  
- 헤더 영역의 `<a class="chat-logo">PetMind</a>` 클릭 시 이동 경로 조건 분기 추가  
- 비회원: 기존과 동일하게 `/chat/main/`으로 이동  
- 회원: 해당 반려견의 ID를 포함한 `/chat/<dog_id>/` 경로로 이동하도록 수정  
- 템플릿 내 `{% if is_guest %}` 조건문 사용하여 링크를 동적으로 설정

## 📋 체크리스트  
- [x] 테스트 완료 (회원/비회원 각각 정상 경로 이동 확인)