### PR TITLE
Refactor: chat image 메인 창에서는 업로드 취소

### DIFF
--- a/web/static/css/chat.css
+++ b/web/static/css/chat.css
@@ -227,7 +227,7 @@ body {
 }
 
 .send-btn {
-  background-color: #FFC508;
+  /* background-color: #FFC508; */
   border: none;
   width: 42px;
   height: 42px;
@@ -353,7 +353,7 @@ body {
   }
 
   .chat-message.bot-message button {
-    background-color: #ffd400;
+    background-color: #FFC508;
     border: none;
     border-radius: 8px;
     color: #000;

--- a/web/templates/chat/chat.html
+++ b/web/templates/chat/chat.html
@@ -59,7 +59,7 @@
             <option value="기타">기타</option>
           </select>
           <button type="submit"
-                  style="padding: 8px 30px; background-color: #ffd400; border: none; border-radius: 8px; color: #000; font-weight: bold;">
+                  style="padding: 8px 30px; background-color: #FFC508; border: none; border-radius: 8px; color: #000; font-weight: bold;">
             확인
           </button>
         </form>
@@ -81,16 +81,11 @@
 
       <form method="POST" action="{% url 'chat:chat_send' %}" enctype="multipart/form-data" class="chat-input-form">
         {% csrf_token %}
-        <textarea name="message" placeholder="질문을 입력하세요." required></textarea>
-        <div id="imagePreviewContainer" style="display: flex; gap: 8px; margin-top: 8px;"></div>
-        <div class="chat-input-bottom">
-          <label class="image-upload-btn" style="visibility: hidden;">
-            <input type="file" name="images" id="imageInput" accept="image/*" multiple hidden>
-            <img src="{% static 'images/image_upload_btn.png' %}" alt="이미지 업로드 아이콘">
-            <span>이미지 업로드</span>
-          </label>
-          <button type="submit" class="send-btn">
-            <img src="{% static 'images/chatbot_sendbtn.png' %}" alt="보내기">
+        <div class="chat-input-row" style="display: flex; align-items: center; gap: 8px;">
+          <textarea name="message" placeholder="질문을 입력하세요." required
+                    style="height: 50px; resize: none; padding: 12px 16px; font-size: 14px; flex: 1; border-radius: 16px;"></textarea>
+          <button type="submit" class="send-btn" style="width: 44px; height: 44px; border-radius: 50%; background-color: #FFC508; display: flex; justify-content: center; align-items: center; border: none;">
+            <img src="{% static 'images/chatbot_sendbtn.png' %}" alt="보내기" style="width: 40px; height: 40px;">
           </button>
         </div>
 


### PR DESCRIPTION
## ✅ PR 요약  
Refactor: chat 이미지 업로드 기능을 메인 페이지에서 비활성화 처리했습니다.

## 🔍 상세 내용  
- 메인(chat main) 페이지에서 이미지 업로드 UI 요소 제거 또는 주석 처리
- `.chat-input-form` 내 이미지 업로드 관련 HTML 제거 및 JS 동작 제거
- 이미지 업로드 버튼 제거로 인해 전송 버튼 위치 재정렬 (가로 배치)
- 입력창 높이 및 정렬 개선을 통해 레이아웃 안정화

## 📋 체크리스트  
- [x] 테스트 완료 (채팅 전송 정상 동작 및 UI 정상 출력 확인)