### PR TITLE
fix: time zone changed

### DIFF
--- a/web/chat/views.py
+++ b/web/chat/views.py
@@ -35,6 +35,7 @@ from urllib.parse import quote
 from django.urls import reverse
 import mimetypes
 from urllib.parse import unquote
+import pytz
 
 
 def chat_entry(request):
@@ -756,8 +757,9 @@ def load_chat_and_profile(chat_id, start_date, end_date):
     }
 
     try:
-        start_dt = make_aware(datetime.strptime(start_date, "%Y-%m-%d"))
-        end_dt = make_aware(datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1))
+        kst = pytz.timezone("Asia/Seoul")
+        start_dt = kst.localize(datetime.strptime(start_date, "%Y-%m-%d"))
+        end_dt = kst.localize(datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1))
     except ValueError:
         return dog_dict, []
 
@@ -773,7 +775,6 @@ def load_chat_and_profile(chat_id, start_date, end_date):
     ]
 
     return dog_dict, history
-
 def chat_report_feedback_view(request, chat_id):
     chat = get_object_or_404(Chat, id=chat_id)
     return render(request, 'chat/chat_report_feedback.html', {


### PR DESCRIPTION
## ✅ PR 요약
RDS에 저장된 UTC 시간 기준에 맞춰 상담 리포트의 날짜 필터링 로직을 KST → UTC 변환 방식으로 수정했습니다.

## 🔍 상세 내용
- `load_chat_and_profile()` 함수 내 `start_date`, `end_date` 값을 `KST timezone-aware datetime`으로 변환
- 기존 `make_aware()` 대신 `pytz.timezone("Asia/Seoul")`로 명시적 지역 시간대 지정 적용
- 리포트 필터링 시 `created_at__gte / __lt` 방식으로 범위 필터링하여 정확한 날짜 데이터만 조회

## 🔗 관련 이슈
- #104 

## 📋 체크리스트
- [x] 테스트 완료


