### PR TITLE
fix: report date

### DIFF
--- a/web/chat/views.py
+++ b/web/chat/views.py
@@ -14,7 +14,7 @@ from django.contrib.auth.decorators import login_required
 from user.utils import get_logged_in_user
 from collections import defaultdict
 from django.http import HttpResponseForbidden
-from datetime import date, timedelta
+from datetime import date, timedelta, time
 from asgiref.sync import sync_to_async
 import uuid
 import requests
@@ -751,6 +751,7 @@ def submit_review(request):
         return JsonResponse({'status': 'invalid_json'}, status=400)
     
 
+
 def load_chat_and_profile(chat_id, start_date, end_date):
     try:
         chat = Chat.objects.select_related("dog").get(id=chat_id)
@@ -774,24 +775,26 @@ def load_chat_and_profile(chat_id, start_date, end_date):
     }
 
     try:
-        kst = pytz.timezone("Asia/Seoul")
-        start_dt = kst.localize(datetime.strptime(start_date, "%Y-%m-%d"))
-        end_dt = kst.localize(datetime.strptime(end_date, "%Y-%m-%d") + timedelta(days=1))
+        start_dt = datetime.strptime(start_date, "%Y-%m-%d")
+        end_dt = datetime.strptime(end_date, "%Y-%m-%d")
+
+        start_dt = make_aware(datetime.combine(start_dt, time.min)) 
+        end_dt = make_aware(datetime.combine(end_dt, time.max))   
     except ValueError:
         return dog_dict, []
 
     messages = Message.objects.filter(
         chat_id=chat_id,
-        created_at__gte=start_dt,
-        created_at__lt=end_dt
+        created_at__range=(start_dt, end_dt)
     ).order_by("created_at")
 
     history = [
         {"role": "user" if msg.sender == "user" else "assistant", "content": msg.message}
         for msg in messages if msg.message
     ]
-
     return dog_dict, history
+
+
 def chat_report_feedback_view(request, chat_id):
     chat = get_object_or_404(Chat, id=chat_id)
     return render(request, 'chat/chat_report_feedback.html', {


### PR DESCRIPTION
## ✅ PR 요약  
KST/UTC 타임존 차이로 인한 상담 리포트 날짜 필터 오류를 수정했습니다.

## 🔍 상세 내용  
- `load_chat_and_profile()` 함수에서 날짜 범위 필터링 로직 개선  
  - 기존: `end_date + 1일` 방식으로 비교 (`created_at__lt`)  
  - 수정: `datetime.combine + time.min/max + make_aware()`로 하루 전체 포함 범위 사용 (`created_at__range`)  
- Django의 `USE_TZ=True` 환경에서 로컬(KST)과 배포(UTC) 간 시간대 불일치로 누락되던 메시지 해결  
- 실제 상담 기록이 있음에도 "상담을 진행하지 않았습니다"라는 오류 발생 문제 해결

## 📋 체크리스트  
- [x] 로컬 테스트 완료 (2025-06-12 ~ 2025-06-16 범위 메시지 정상 조회 확인)  